### PR TITLE
changed to raw knex to allow for rollback of table drops

### DIFF
--- a/db/migrations/20170902134330_create_posts.js
+++ b/db/migrations/20170902134330_create_posts.js
@@ -53,11 +53,11 @@ exports.up = function (knex, Promise) {
  
 exports.down = function(knex, Promise) {
   return Promise.all([
-    knex.schema.dropTable('posts'),
-    knex.schema.dropTable('location'),
-    knex.schema.dropTable('companies'),
-    knex.schema.dropTable('news'),
-    knex.schema.dropTable('lifecycle'),
-    knex.schema.dropTable('interaction')
+    knex.raw('DROP TABLE posts CASCADE'),
+    knex.raw('DROP TABLE location CASCADE'),
+    knex.raw('DROP TABLE companies CASCADE'),
+    knex.raw('DROP TABLE news CASCADE'),
+    knex.raw('DROP TABLE lifecycle CASCADE'),
+    knex.raw('DROP TABLE interaction CASCADE')
   ]);
 };


### PR DESCRIPTION
changed to raw sql to override the foreign key constraints implemented when creating the tables. 